### PR TITLE
#36 Handle crawl files option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,8 @@ gulp.src('./js/*.js')
 #### Available Settings
 ##### See the [customizr repository](https://github.com/Modernizr/customizr#config-file) for valid settings.
 
-#### `settings.crawl`
-Currently not passed on to customizr, see [issue #36](https://github.com/rejas/gulp-modernizr/issues/36) 
-
 #### `settings.quiet`
-Defaults to false, setting it to true suppresses any log output from customizr
+Defaults to `false`, setting it to `true` suppresses any log output from customizr
 
 #### `settings.uglify`
 Will never be passed to customizr, see the [Gulp guidelines](https://github.com/gulpjs/gulp/blob/master/docs/writing-a-plugin/guidelines.md). The option to uglify the build goes against guidelines #1 and #3. Thus, this setting has been removed from this plugin. You may use [`gulp-uglify`](https://npmjs.org/package/gulp-uglify) to achieve this functionality in Gulp:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ and in this case add the 'objectfit' test to the ouptut file.
 #### fileName
 Type: `String`
 
-You can optionally pass a fileName to name the Modernizr file (defaults to 'modernizr.js')
+You can optionally pass a fileName to name the Modernizr file (defaults to `modernizr.js`)
 
 ```javascript
 gulp.src('./js/*.js')
@@ -96,6 +96,21 @@ gulp.src('./js/*.js')
 
 #### Available Settings
 ##### See the [customizr repository](https://github.com/Modernizr/customizr#config-file) for valid settings.
+
+#### `settings.crawl`
+
+- If set to `true`, customizr will crawl your file for tests and add them to your Modernizr file
+- If set to `false`, customizr will not crawl your files. If you specified custom tests, they will be added to your Modernizr file
+- If you just want to output a Modernizr file without crawling any file, pass a fake string as gulp source:
+
+```javascript
+gulp.src('fake', {allowEmpty: true})
+  .pipe(modernizr({
+    ...settings
+  }))
+
+```
+
 
 #### `settings.quiet`
 Defaults to `false`, setting it to `true` suppresses any log output from customizr

--- a/README.md
+++ b/README.md
@@ -97,21 +97,6 @@ gulp.src('./js/*.js')
 #### Available Settings
 ##### See the [customizr repository](https://github.com/Modernizr/customizr#config-file) for valid settings.
 
-#### `settings.crawl`
-
-- If set to `true`, customizr will crawl your file for tests and add them to your Modernizr file
-- If set to `false`, customizr will not crawl your files. If you specified custom tests, they will be added to your Modernizr file
-- If you just want to output a Modernizr file without crawling any file, pass a fake string as gulp source:
-
-```javascript
-gulp.src('fake', {allowEmpty: true})
-  .pipe(modernizr({
-    ...settings
-  }))
-
-```
-
-
 #### `settings.quiet`
 Defaults to `false`, setting it to `true` suppresses any log output from customizr
 
@@ -123,6 +108,19 @@ gulp.src('./js/*.js')
   .pipe(modernizr())
   .pipe(uglify())
   .pipe(gulp.dest("build/"));
+```
+
+#### Notes on `settings.crawl`
+
+By default, `glup-modernizr` will not ouput any `Modernizr.js` if your `gulp.src` does not return any file, regardless of the `tests` you may have set.
+
+If you only want to ouput a `Modernizr.js` file with some `tests` you set, just pass a fake path to `gulp.src`:
+
+```javascript
+gulp.src('fake', {allowEmpty: true})
+  .pipe(modernizr({
+    ...settings
+  }))
 ```
 
 [modernizr-travis-url]: https://travis-ci.org/rejas/gulp-modernizr

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ module.exports = function(fileName, opt) {
   // Ensure opt exists
   opt = opt || {};
 
+  var crawlFiles = opt.crawl;
+
   // Enable string parsing in customizr
   opt.useBuffers = true;
 
@@ -38,8 +40,7 @@ module.exports = function(fileName, opt) {
   opt.uglify = false;
 
   // Save first file for metadata purposes
-  var firstFile,
-    stream;
+  var stream;
 
   function storeBuffers(file, enc, callback) {
 
@@ -59,11 +60,6 @@ module.exports = function(fileName, opt) {
       return callback();
     }
 
-    // Set first file
-    if (!firstFile) {
-      firstFile = file;
-    }
-
     // Save buffer for later use
     opt.files.src.push(file);
 
@@ -71,8 +67,13 @@ module.exports = function(fileName, opt) {
   }
 
   function generateModernizr(callback) {
-    if (opt.files.src.length === 0) {
+    if (crawlFiles && opt.files.src.length === 0) {
       return callback();
+    }
+
+    // Remove files if crawl is set to false
+    if (!crawlFiles) {
+      opt.files.src = [];
     }
 
     // Call customizr
@@ -88,9 +89,9 @@ module.exports = function(fileName, opt) {
 
       // Save result
       var file = new Vinyl({
-        path: path.join(firstFile.base, fileName),
-        base: firstFile.base,
-        cwd: firstFile.cwd,
+        path: fileName,
+        base: undefined,
+        cwd: '',
         contents: Buffer.from(data.result),
       });
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function(fileName, opt) {
   // Ensure opt exists
   opt = opt || {};
 
-  var crawlFiles = opt.crawl;
+  var crawlFiles = opt.hasOwnProperty('crawl') ? opt.crawl : true;
 
   // Enable string parsing in customizr
   opt.useBuffers = true;

--- a/index.js
+++ b/index.js
@@ -38,7 +38,6 @@ module.exports = function(fileName, opt) {
   // "Your plugin shouldn't do things that other plugins are responsible for"
   opt.uglify = false;
 
-  // Save first file for metadata purposes
   var stream;
 
   function storeBuffers(file, enc, callback) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var path = require('path');
 var PluginError = require('plugin-error');
 var Vinyl = require('vinyl');
 var through = require('through2');

--- a/test/tests.js
+++ b/test/tests.js
@@ -3,6 +3,7 @@
 var fs = require('fs');
 var assert = require('chai').assert;
 var Vinyl = require('vinyl');
+var gs = require('glob-stream');
 var modernizr = require('../');
 
 describe('gulp-modernizr', function() {
@@ -27,5 +28,55 @@ describe('gulp-modernizr', function() {
 
       stream.end();
     });
+
+    it('should generate a custom Modernizr file with custom tests', function(done) {
+
+      var stream = modernizr({
+        crawl: false,
+        'tests': [
+          'touchevents',
+        ],
+      });
+
+      var TEST_PATH = __dirname + '/vanilla.js';
+
+      stream.on('data', function(file) {
+        assert.notEqual(-1, String(file.path).indexOf('modernizr.js'));
+        assert.equal(-1, String(file.contents).indexOf('webworkers'));
+
+        done();
+      });
+
+      stream.write(new Vinyl({
+        path: TEST_PATH,
+        contents: fs.readFileSync(TEST_PATH),
+      }));
+
+      stream.end();
+
+    });
+
+    it('should generate a custom Modernizr file with custom tests and no source files', function(done) {
+
+      var stream = gs('fake', {allowEmpty: true})
+        .pipe(modernizr({
+          crawl: false,
+          'tests': [
+            'touchevents',
+          ],
+        })
+      );
+
+      stream.on('data', function(file) {
+        assert.notEqual(-1, String(file.path).indexOf('modernizr.js'));
+        assert.notEqual(-1, String(file.contents).indexOf('touchevents'));
+
+        done();
+      });
+
+      stream.end();
+
+    });
+
   });
 });


### PR DESCRIPTION
Hi, 

This PR adresses issue #36 (and maybe #35 too). 

Also, you now don't depend on having files in your `gulp.src`. 
```js
gulp.src('fake')
  .modernizr({ 
    crawl: false,
    tests: [
      'touchevents'
     ]
  })
  .dest('/build')
```
